### PR TITLE
Add build-secrets Dockerfile and build.js script

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,15 @@
+---
+docker:
+  builds:
+    - path: src/build-secrets
+      dockerfile: Dockerfile-386
+      docker_repo: balena/386-balena-multibuild-scripts
+    - path: src/build-secrets
+      dockerfile: Dockerfile-amd64
+      docker_repo: balena/amd64-balena-multibuild-scripts
+    - path: src/build-secrets
+      dockerfile: Dockerfile-arm
+      docker_repo: balena/arm-balena-multibuild-scripts
+    - path: src/build-secrets
+      dockerfile: Dockerfile-arm64
+      docker_repo: balena/arm64-balena-multibuild-scripts

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: 'docker'

--- a/src/build-secrets/Dockerfile-386
+++ b/src/build-secrets/Dockerfile-386
@@ -1,0 +1,4 @@
+FROM i386/alpine:3.10
+RUN apk update && apk add bash jq
+WORKDIR /usr/src
+COPY populate.sh remove.sh /usr/src/

--- a/src/build-secrets/Dockerfile-amd64
+++ b/src/build-secrets/Dockerfile-amd64
@@ -1,0 +1,4 @@
+FROM amd64/alpine:3.10
+RUN apk update && apk add bash jq
+WORKDIR /usr/src
+COPY populate.sh remove.sh /usr/src/

--- a/src/build-secrets/Dockerfile-arm
+++ b/src/build-secrets/Dockerfile-arm
@@ -1,0 +1,6 @@
+FROM balenalib/armv7hf-alpine:3.10
+RUN ["cross-build-start"]
+RUN apk update && apk add bash jq
+RUN ["cross-build-end"]
+WORKDIR /usr/src
+COPY populate.sh remove.sh /usr/src/

--- a/src/build-secrets/Dockerfile-arm64
+++ b/src/build-secrets/Dockerfile-arm64
@@ -1,0 +1,6 @@
+FROM balenalib/aarch64-alpine:3.10
+RUN ["cross-build-start"]
+RUN apk update && apk add bash jq
+RUN ["cross-build-end"]
+WORKDIR /usr/src
+COPY populate.sh remove.sh /usr/src/

--- a/src/build-secrets/populate.sh
+++ b/src/build-secrets/populate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+while read -r name content; do
+	mkdir -p $(dirname "$name")
+	echo  "$content" | base64 -d > "$name";
+done <<< $(jq --raw-output '. as $top | keys[] as $k | .[$k].files | keys[] as $f | "\($top[$k].tmpDirectory + "/" + $f) \(.[$f])"' secrets.json)
+

--- a/src/build-secrets/remove.sh
+++ b/src/build-secrets/remove.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while read -r dir; do
+	rm -rf $dir;
+done <<< $(jq --raw-output '.[]' remove.json);


### PR DESCRIPTION
This PR number 1 for this new repo is a counterpart to https://github.com/balena-io-modules/resin-multibuild/pull/63, creating a pre-built external base image for use by `resin-multibuild`.

Change-type: minor
Signed-off-by: Paulo Castro <paulo@balena.io>